### PR TITLE
Update Rust version and dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,14 +2,14 @@
 name = "sedecim"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.87"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-crossterm = { version = "0.19", features = [ "serde" ] }
+crossterm = { version = "0.25", features = ["serde"] }
 serde = {version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
-rand = { version = "0.7.3", default-features = false, features = ["std"] }
-tui = { version = "0.19", default-features = false, features = ['crossterm', 'serde'] }
+tui = { version = "0.19", default-features = false, features = ["crossterm", "serde"] }
 thiserror = "1.0"


### PR DESCRIPTION
## Summary
- specify Rust 1.87 as the minimum supported version
- upgrade to crossterm 0.25 and clean up unused rand dependency
- retain current tui backend configuration

## Testing
- `cargo build --offline`
- `cargo test --offline`

------
https://chatgpt.com/codex/tasks/task_e_6899504a6ea08322a11bb720a63b1efc